### PR TITLE
chore: rename repo to skill-sdk (#52)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Thanks for your interest in contributing! This guide covers how to contribute co
 
 ```bash
 # Clone and install
-git clone https://github.com/Pratiyush/agentic-skills-framework.git
-cd agentic-skills-framework
+git clone https://github.com/Pratiyush/skill-sdk.git
+cd skill-sdk
 pnpm install
 
 # Build all packages

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **The TypeScript toolkit for building, validating, and shipping Agent Skills.**
 
 [![npm version](https://img.shields.io/badge/npm-pre--release-orange?style=flat-square)](https://www.npmjs.com/package/@skillscraft/core)
-[![CI](https://img.shields.io/github/actions/workflow/status/Pratiyush/agentic-skills-framework/ci.yml?style=flat-square)](https://github.com/Pratiyush/agentic-skills-framework/actions)
+[![CI](https://img.shields.io/github/actions/workflow/status/Pratiyush/skill-sdk/ci.yml?style=flat-square)](https://github.com/Pratiyush/skill-sdk/actions)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg?style=flat-square)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
 
@@ -185,22 +185,22 @@ Claude Code, GitHub Copilot, Cursor, OpenAI Codex, VS Code, Gemini CLI, JetBrain
 
 ## Specification
 
-The Agent Skills specification defines a portable format for giving AI agents new capabilities. See the [full specification reference](https://pratiyush.github.io/agentic-skills-framework/specification.html).
+The Agent Skills specification defines a portable format for giving AI agents new capabilities. See the [full specification reference](https://pratiyush.github.io/skill-sdk/specification.html).
 
 ### Adopters
 
-Skills built with this format are supported by: Claude Code, GitHub Copilot, Cursor, OpenAI Codex, VS Code, Gemini CLI, JetBrains Junie, Windsurf, Goose, Roo Code, Amp, OpenCode, Aider, Open-Claw, and more. See the [install command](https://pratiyush.github.io/agentic-skills-framework/tutorial.html) for the full target list.
+Skills built with this format are supported by: Claude Code, GitHub Copilot, Cursor, OpenAI Codex, VS Code, Gemini CLI, JetBrains Junie, Windsurf, Goose, Roo Code, Amp, OpenCode, Aider, Open-Claw, and more. See the [install command](https://pratiyush.github.io/skill-sdk/tutorial.html) for the full target list.
 
 ## Marketplace
 
-Browse and install production skills from [SkillsCraft Hub](https://github.com/Pratiyush/skillscraft-hub).
+Browse and install production skills from [Agent Catalog](https://github.com/Pratiyush/agent-catalog).
 
 ## Links
 
-- [Specification Reference](https://pratiyush.github.io/agentic-skills-framework/specification.html)
-- [Concepts Guide](https://pratiyush.github.io/agentic-skills-framework/concepts.html)
-- [SDK Tutorial](https://pratiyush.github.io/agentic-skills-framework/tutorial.html)
-- [Documentation Site](https://pratiyush.github.io/agentic-skills-framework)
+- [Specification Reference](https://pratiyush.github.io/skill-sdk/specification.html)
+- [Concepts Guide](https://pratiyush.github.io/skill-sdk/concepts.html)
+- [SDK Tutorial](https://pratiyush.github.io/skill-sdk/tutorial.html)
+- [Documentation Site](https://pratiyush.github.io/skill-sdk)
 
 ## Contributing
 

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -25,8 +25,8 @@
         <a href="concepts.html">Concepts</a>
         <a href="specification.html">Specification</a>
         <a href="tutorial.html">Tutorial</a>
-        <a href="https://github.com/Pratiyush/skillscraft-hub" target="_blank" rel="noopener noreferrer">Marketplace</a>
-        <a href="https://github.com/Pratiyush/agentic-skills-framework" target="_blank" rel="noopener noreferrer" class="nav-github" aria-label="GitHub repository">
+        <a href="https://github.com/Pratiyush/agent-catalog" target="_blank" rel="noopener noreferrer">Marketplace</a>
+        <a href="https://github.com/Pratiyush/skill-sdk" target="_blank" rel="noopener noreferrer" class="nav-github" aria-label="GitHub repository">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
         </a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">
@@ -430,7 +430,7 @@ description: >
 
       <div class="callout warn">
         <strong>Enterprise warning</strong>
-        The current spec has no security model. Skills cannot declare capabilities, sign their contents, or be verified. The <a href="https://github.com/Pratiyush/agentic-skills-framework">@skillscraft extended spec</a> is working to address this with capability declarations, credential requirements, and signed skills.
+        The current spec has no security model. Skills cannot declare capabilities, sign their contents, or be verified. The <a href="https://github.com/Pratiyush/skill-sdk">@skillscraft extended spec</a> is working to address this with capability declarations, credential requirements, and signed skills.
       </div>
     </section>
 
@@ -451,7 +451,7 @@ description: >
 
   <footer>
     <div class="container">
-      <p><a href="https://github.com/Pratiyush/agentic-skills-framework">Agentic Skills Framework</a> &middot; Apache-2.0</p>
+      <p><a href="https://github.com/Pratiyush/skill-sdk">Agentic Skills Framework</a> &middot; Apache-2.0</p>
     </div>
   </footer>
   <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
   <meta name="keywords" content="agent skills, agentskills, AI agents, skill framework, Claude Code, GitHub Copilot, Cursor, TypeScript, validator, linter">
   <meta property="og:title" content="Agentic Skills Framework">
   <meta property="og:description" content="The TypeScript toolkit for building, validating, and shipping Agent Skills.">
-  <meta property="og:url" content="https://pratiyush.github.io/agentic-skills-framework">
+  <meta property="og:url" content="https://pratiyush.github.io/skill-sdk">
   <meta property="og:type" content="website">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -28,8 +28,8 @@
         <a href="concepts.html">Concepts</a>
         <a href="specification.html">Specification</a>
         <a href="tutorial.html">Tutorial</a>
-        <a href="https://github.com/Pratiyush/skillscraft-hub" target="_blank" rel="noopener noreferrer">Marketplace</a>
-        <a href="https://github.com/Pratiyush/agentic-skills-framework" target="_blank" rel="noopener noreferrer" class="nav-github" aria-label="GitHub repository">
+        <a href="https://github.com/Pratiyush/agent-catalog" target="_blank" rel="noopener noreferrer">Marketplace</a>
+        <a href="https://github.com/Pratiyush/skill-sdk" target="_blank" rel="noopener noreferrer" class="nav-github" aria-label="GitHub repository">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
         </a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">
@@ -53,8 +53,8 @@
         </div>
         <div class="hero-badges">
           <a href="https://www.npmjs.com/package/@skillscraft/core"><img src="https://img.shields.io/npm/v/@skillscraft/core?style=flat-square&label=npm" alt="npm" loading="lazy"></a>
-          <a href="https://github.com/Pratiyush/agentic-skills-framework/actions"><img src="https://img.shields.io/github/actions/workflow/status/Pratiyush/agentic-skills-framework/ci.yml?style=flat-square&label=CI" alt="CI" loading="lazy"></a>
-          <a href="https://github.com/Pratiyush/agentic-skills-framework"><img src="https://img.shields.io/github/stars/Pratiyush/agentic-skills-framework?style=flat-square" alt="Stars" loading="lazy"></a>
+          <a href="https://github.com/Pratiyush/skill-sdk/actions"><img src="https://img.shields.io/github/actions/workflow/status/Pratiyush/skill-sdk/ci.yml?style=flat-square&label=CI" alt="CI" loading="lazy"></a>
+          <a href="https://github.com/Pratiyush/skill-sdk"><img src="https://img.shields.io/github/stars/Pratiyush/skill-sdk?style=flat-square" alt="Stars" loading="lazy"></a>
           <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg?style=flat-square" alt="License" loading="lazy">
         </div>
       </div>
@@ -251,12 +251,12 @@ Use this when the user asks you to review code, a pull request, or a diff.
             <p>Complete reference for frontmatter, validation rules, lint rules, and extended spec.</p>
             <span class="card-arrow">&rarr;</span>
           </a>
-          <a href="https://github.com/Pratiyush/skillscraft-hub" class="card card-link" target="_blank">
+          <a href="https://github.com/Pratiyush/agent-catalog" class="card card-link" target="_blank">
             <h3>Marketplace</h3>
             <p>Browse and install production skills from SkillsCraft Hub.</p>
             <span class="card-arrow">&rarr;</span>
           </a>
-          <a href="https://github.com/Pratiyush/agentic-skills-framework/blob/master/CONTRIBUTING.md" class="card card-link" target="_blank">
+          <a href="https://github.com/Pratiyush/skill-sdk/blob/master/CONTRIBUTING.md" class="card card-link" target="_blank">
             <h3>Contributing</h3>
             <p>How to contribute code, lint rules, and skill templates.</p>
             <span class="card-arrow">&rarr;</span>
@@ -268,7 +268,7 @@ Use this when the user asks you to review code, a pull request, or a diff.
 
   <footer>
     <div class="container">
-      <p><a href="https://github.com/Pratiyush/agentic-skills-framework">Agentic Skills Framework</a> &middot; Apache-2.0</p>
+      <p><a href="https://github.com/Pratiyush/skill-sdk">Agentic Skills Framework</a> &middot; Apache-2.0</p>
     </div>
   </footer>
 

--- a/docs/specification.html
+++ b/docs/specification.html
@@ -22,8 +22,8 @@
         <a href="concepts.html">Concepts</a>
         <a href="specification.html" class="active">Specification</a>
         <a href="tutorial.html">Tutorial</a>
-        <a href="https://github.com/Pratiyush/skillscraft-hub" target="_blank" rel="noopener noreferrer">Marketplace</a>
-        <a href="https://github.com/Pratiyush/agentic-skills-framework" target="_blank" rel="noopener noreferrer" class="nav-github" aria-label="GitHub repository">
+        <a href="https://github.com/Pratiyush/agent-catalog" target="_blank" rel="noopener noreferrer">Marketplace</a>
+        <a href="https://github.com/Pratiyush/skill-sdk" target="_blank" rel="noopener noreferrer" class="nav-github" aria-label="GitHub repository">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
         </a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">
@@ -384,7 +384,7 @@
 
   <footer>
     <div class="container">
-      <p><a href="https://github.com/Pratiyush/agentic-skills-framework">Agentic Skills Framework</a> &middot; Apache-2.0</p>
+      <p><a href="https://github.com/Pratiyush/skill-sdk">Agentic Skills Framework</a> &middot; Apache-2.0</p>
     </div>
   </footer>
   <script>

--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -23,8 +23,8 @@
         <a href="concepts.html">Concepts</a>
         <a href="specification.html">Specification</a>
         <a href="tutorial.html" class="active">Tutorial</a>
-        <a href="https://github.com/Pratiyush/skillscraft-hub" target="_blank" rel="noopener noreferrer">Marketplace</a>
-        <a href="https://github.com/Pratiyush/agentic-skills-framework" target="_blank" rel="noopener noreferrer" class="nav-github" aria-label="GitHub repository">
+        <a href="https://github.com/Pratiyush/agent-catalog" target="_blank" rel="noopener noreferrer">Marketplace</a>
+        <a href="https://github.com/Pratiyush/skill-sdk" target="_blank" rel="noopener noreferrer" class="nav-github" aria-label="GitHub repository">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
         </a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">
@@ -428,7 +428,7 @@ skill info ./my-skill
 
   <footer>
     <div class="container">
-      <p><a href="https://github.com/Pratiyush/agentic-skills-framework">Agentic Skills Framework</a> &middot; Apache-2.0</p>
+      <p><a href="https://github.com/Pratiyush/skill-sdk">Agentic Skills Framework</a> &middot; Apache-2.0</p>
     </div>
   </footer>
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentic-skills-framework",
+  "name": "skill-sdk",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -69,6 +69,6 @@ Apache-2.0
 
 ## Links
 
-- [Main repository](https://github.com/Pratiyush/agentic-skills-framework)
-- [Documentation](https://pratiyush.github.io/agentic-skills-framework)
-- [Marketplace](https://github.com/Pratiyush/skillscraft-hub)
+- [Main repository](https://github.com/Pratiyush/skill-sdk)
+- [Documentation](https://pratiyush.github.io/skill-sdk)
+- [Marketplace](https://github.com/Pratiyush/agent-catalog)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,11 @@
     "@types/node": "^25.5.2"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Pratiyush/agentic-skills-framework",
+    "url": "https://github.com/Pratiyush/skill-sdk",
     "directory": "packages/cli"
   },
   "keywords": ["agent-skills", "cli", "skill-builder", "validator", "linter"]

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -4,6 +4,7 @@ import { mkdir, copyFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 import { parseSkill, validateSkill, loadSkillIgnore, isIgnored } from "@skillscraft/core";
+import { resolveRegistry } from "../registry.js";
 
 /**
  * Target agent install paths.
@@ -114,12 +115,42 @@ function resolveRemoteSource(source: string): string {
     } else {
       subpath = parts.slice(2).join("/");
     }
+  } else if (source.startsWith("gitlab:")) {
+    // gitlab:owner/repo/path/to/skill
+    const rest = source.slice("gitlab:".length);
+    const parts = rest.split("/");
+    if (parts.length < 2) {
+      throw new Error(
+        `Invalid gitlab: source "${source}". Expected: gitlab:owner/repo[/path/to/skill]`
+      );
+    }
+    owner = parts[0];
+    repo = parts[1];
+    subpath = parts.slice(2).join("/");
+  } else if (source.startsWith("https://gitlab.com/")) {
+    // https://gitlab.com/owner/repo/-/tree/branch/path
+    const url = new URL(source);
+    const parts = url.pathname.replace(/^\//, "").split("/");
+    if (parts.length < 2) {
+      throw new Error(`Invalid GitLab URL "${source}"`);
+    }
+    owner = parts[0];
+    repo = parts[1].replace(/\.git$/, "");
+    if (parts[2] === "-" && parts[3] === "tree" && parts[4]) {
+      branch = parts[4];
+      subpath = parts.slice(5).join("/");
+    } else {
+      subpath = parts.slice(2).filter(p => p !== "-").join("/");
+    }
   } else {
     throw new Error(`Unsupported remote source: ${source}`);
   }
 
   const tmpDir = mkdtempSync(join(tmpdir(), "skillscraft-"));
-  const cloneUrl = `https://github.com/${owner}/${repo}.git`;
+  const isGitLab = source.includes("gitlab");
+  const cloneUrl = isGitLab
+    ? `https://gitlab.com/${owner}/${repo}.git`
+    : `https://github.com/${owner}/${repo}.git`;
 
   console.log(`Fetching ${owner}/${repo} (${branch})...`);
   try {
@@ -149,6 +180,31 @@ function resolveRemoteSource(source: string): string {
   return resolvedPath;
 }
 
+/**
+ * Resolve a skill name from the registry index.json.
+ * Returns a github: URL or HTTPS URL to the skill.
+ */
+async function resolveFromRegistry(name: string): Promise<string | null> {
+  const registry = resolveRegistry();
+  const indexUrl = `${registry}/index.json`;
+
+  try {
+    const response = await fetch(indexUrl);
+    if (!response.ok) return null;
+
+    const index = (await response.json()) as {
+      skills: Array<{ name: string; url: string }>;
+    };
+    const entry = index.skills.find((s) => s.name === name);
+    if (!entry) return null;
+
+    // Return the full URL to the skill
+    return `${registry}/${entry.url}`;
+  } catch {
+    return null;
+  }
+}
+
 interface InstallOptions {
   target: string;
   scope: string;
@@ -162,13 +218,38 @@ export async function installCommand(
 ): Promise<void> {
   const { target = "generic", scope = "project", force = false, skipValidation = false } = options;
 
-  // Detect remote source (github: or https://github.com/...)
-  let sourceDir: string;
+  // Check if this is a bare skill name (registry lookup)
+  const isPath =
+    skillPath.startsWith(".") ||
+    skillPath.startsWith("/") ||
+    skillPath.startsWith("~") ||
+    skillPath.includes("/");
   const isRemote =
     skillPath.startsWith("github:") ||
-    skillPath.startsWith("https://github.com/");
+    skillPath.startsWith("gitlab:") ||
+    skillPath.startsWith("https://github.com/") ||
+    skillPath.startsWith("https://gitlab.com/");
 
-  if (isRemote) {
+  if (!isPath && !isRemote) {
+    console.log(`Looking up "${skillPath}" in registry...`);
+    const registryUrl = await resolveFromRegistry(skillPath);
+    if (registryUrl) {
+      console.log(`Found in registry: ${registryUrl}`);
+      skillPath = registryUrl;
+    } else {
+      console.error(`Error: Skill "${skillPath}" not found in registry.`);
+      console.error(`Registry: ${resolveRegistry()}`);
+      console.error(
+        `\nProvide a direct path, github: URL, or gitlab: URL instead.`
+      );
+      process.exit(1);
+    }
+  }
+
+  // Detect remote source (github:, gitlab:, or URL)
+  let sourceDir: string;
+
+  if (isRemote || skillPath.startsWith("github:") || skillPath.startsWith("gitlab:") || skillPath.startsWith("https://")) {
     try {
       sourceDir = resolveRemoteSource(skillPath);
     } catch (err) {

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -1,0 +1,63 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const DEFAULT_REGISTRY = "https://pratiyush.github.io/agent-catalog";
+
+interface RegistryConfig {
+  registry: string;
+}
+
+/**
+ * Resolve the skill registry URL.
+ * Priority: SKILL_REGISTRY env var > ~/.skillrc > .skillrc > default
+ */
+export function resolveRegistry(): string {
+  // 1. Environment variable
+  if (process.env.SKILL_REGISTRY) {
+    return process.env.SKILL_REGISTRY.replace(/\/+$/, "");
+  }
+
+  // 2. User-level config
+  const userRc = join(homedir(), ".skillrc");
+  if (existsSync(userRc)) {
+    const config = parseRcFile(userRc);
+    if (config.registry) return config.registry;
+  }
+
+  // 3. Project-level config
+  const projectRc = join(process.cwd(), ".skillrc");
+  if (existsSync(projectRc)) {
+    const config = parseRcFile(projectRc);
+    if (config.registry) return config.registry;
+  }
+
+  // 4. Default
+  return DEFAULT_REGISTRY;
+}
+
+function parseRcFile(filePath: string): RegistryConfig {
+  try {
+    const content = readFileSync(filePath, "utf-8");
+
+    // Try JSON first
+    if (content.trim().startsWith("{")) {
+      return JSON.parse(content);
+    }
+
+    // Simple key=value format
+    const config: RegistryConfig = { registry: "" };
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const [key, ...valueParts] = trimmed.split("=");
+      const value = valueParts.join("=").trim();
+      if (key.trim() === "registry") {
+        config.registry = value.replace(/\/+$/, "");
+      }
+    }
+    return config;
+  } catch {
+    return { registry: "" };
+  }
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -64,5 +64,5 @@ Apache-2.0
 
 ## Links
 
-- [Main repository](https://github.com/Pratiyush/agentic-skills-framework)
-- [Documentation](https://pratiyush.github.io/agentic-skills-framework)
+- [Main repository](https://github.com/Pratiyush/skill-sdk)
+- [Documentation](https://pratiyush.github.io/skill-sdk)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Pratiyush/agentic-skills-framework",
+    "url": "https://github.com/Pratiyush/skill-sdk",
     "directory": "packages/core"
   },
   "keywords": ["agent-skills", "agentskills", "validator", "linter", "parser", "ai-agents"]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,11 @@
     "@types/node": "^25.5.2"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -55,5 +55,5 @@ Apache-2.0
 
 ## Links
 
-- [Main repository](https://github.com/Pratiyush/agentic-skills-framework)
-- [Documentation](https://pratiyush.github.io/agentic-skills-framework)
+- [Main repository](https://github.com/Pratiyush/skill-sdk)
+- [Documentation](https://pratiyush.github.io/skill-sdk)

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Pratiyush/agentic-skills-framework",
+    "url": "https://github.com/Pratiyush/skill-sdk",
     "directory": "packages/spec"
   },
   "keywords": ["agent-skills", "agentskills", "skill-spec", "ai-agents", "typescript"]

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -30,7 +30,11 @@
     "@types/node": "^25.5.2"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/spec/schemas/skill.schema.json
+++ b/packages/spec/schemas/skill.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/Pratiyush/agentic-skills-framework/blob/master/packages/spec/schemas/skill.schema.json",
+  "$id": "https://github.com/Pratiyush/skill-sdk/blob/master/packages/spec/schemas/skill.schema.json",
   "title": "SkillFrontmatter",
   "description": "YAML frontmatter schema for SKILL.md files",
   "type": "object",


### PR DESCRIPTION
Update all internal refs from agentic-skills-framework to skill-sdk, skillscraft-hub to agent-catalog. Preserves npm package names.