### PR TITLE
docs: document OpenClaw install target

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
 
 Build, validate, lint, and publish Agent Skills that work across
-**Claude Code, GitHub Copilot, Cursor, OpenAI Codex, Gemini CLI, VS Code**, and 25+ more agents.
+**Claude Code, GitHub Copilot, Cursor, OpenAI Codex, Open-Claw, Gemini CLI, VS Code**, and 25+ more agents.
 
 </div>
 
@@ -110,6 +110,7 @@ Install a skill for a specific agent.
 skill install ./my-skill                          # Install for generic agent
 skill install ./my-skill -t claude                 # Install for Claude Code
 skill install github:owner/repo/path -t copilot    # Install from GitHub
+skill install github:Xquik-dev/tweetclaw/skills/tweetclaw -t open-claw
 skill install ./my-skill --skip-validation          # Skip validation (WIP skills)
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,10 +56,11 @@ Install a skill for a specific agent or generically.
 skill install ./my-skill
 skill install ./my-skill --target claude --scope project
 skill install ./my-skill --target copilot --scope user --force
+skill install github:Xquik-dev/tweetclaw/skills/tweetclaw -t open-claw
 ```
 
 **Options:**
-- `-t, --target <target>` -- target agent: `claude`, `copilot`, `codex`, `generic` (default: `generic`)
+- `-t, --target <target>` -- target agent: `claude`, `copilot`, `codex`, `cursor`, `windsurf`, `aider`, `goose`, `gemini`, `junie`, `roo-code`, `opencode`, `amp`, `open-claw`, `generic` (default: `generic`)
 - `-s, --scope <scope>` -- install scope: `project` or `user` (default: `project`)
 - `-f, --force` -- overwrite existing installation
 

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -77,6 +77,8 @@ const TARGET_PATHS: Record<string, Record<string, string>> = {
   },
 };
 
+const SUPPORTED_TARGETS = Object.keys(TARGET_PATHS).join(", ");
+
 /**
  * Resolve remote sources (github:owner/repo/path, https://github.com/...) to a local directory.
  * Returns the local path to a temp clone containing the skill.
@@ -305,7 +307,7 @@ export async function installCommand(
   // Determine target directory
   if (!TARGET_PATHS[target]) {
     console.error(
-      `Error: Unknown target "${target}". Use: claude, copilot, codex, or generic.`
+      `Error: Unknown target "${target}". Use: ${SUPPORTED_TARGETS}.`
     );
     process.exit(1);
   }

--- a/packages/cli/tests/install.test.ts
+++ b/packages/cli/tests/install.test.ts
@@ -27,6 +27,10 @@ const TARGET_PATHS: Record<string, Record<string, string>> = {
     project: ".codex/skills",
     user: "",
   },
+  "open-claw": {
+    project: ".openclaw/skills",
+    user: "",
+  },
   generic: {
     project: ".agents/skills",
     user: "",
@@ -117,6 +121,12 @@ describe("install command logic", () => {
       scope: "project",
     });
     expect(codexDest).toBe(join(tempDir, ".codex/skills", "my-skill"));
+
+    const openClawDest = computeDestDir(tempDir, "my-skill", {
+      target: "open-claw",
+      scope: "project",
+    });
+    expect(openClawDest).toBe(join(tempDir, ".openclaw/skills", "my-skill"));
 
     const genericDest = computeDestDir(tempDir, "my-skill", {
       target: "generic",


### PR DESCRIPTION
## Summary
- document `open-claw` as an install target in the root and CLI READMEs
- add a real GitHub skill install example using TweetClaw
- derive the unknown-target error from `TARGET_PATHS` and cover the OpenClaw path in install tests

## Validation
- `pnpm test`
- `pnpm build`
- `pnpm lint` passes with existing warnings in untouched files
- `pnpm typecheck`
- `npx markdown-link-check README.md packages/cli/README.md`
- diff whitespace check passed
- `pnpm format:check` is still red on base formatting drift across 14 existing files, including files unrelated to this change